### PR TITLE
feature: github action to auto update tailscale version

### DIFF
--- a/.github/workflow/autoupdate.yml
+++ b/.github/workflow/autoupdate.yml
@@ -1,0 +1,32 @@
+name: Auto Update
+
+on:
+  schedule:
+    - cron:  '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  Update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+    - name: Get data
+      id: data
+      run: |
+        echo "##[set-output name=branch;]${GITHUB_REF##*/}"
+    - name: Create local changes
+      run: |
+        current_version=$(head -n1 Dockerfile | sed -e "s/^ARG TSVERSION=//")
+        latest_version=$(curl https://pkgs.tailscale.com/stable/ | grep tailscale_ -m 1 | cut -d'_' -f 2)
+        if [ "$current_version" != "$latest_version" ]; then
+          sed -i "1 s/.*/ARG TSVERSION=$latest_version/" Dockerfile
+        fi
+    - name: Commit & Push changes
+      uses: actions-js/push@master
+      with:
+        branch: ${{ steps.data.outputs.branch }}
+        message: "Auto Update"
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG TSFILE=tailscale_1.26.2_amd64.tgz
+ARG TSVERSION=1.26.2
+ARG TSFILE=tailscale_${TSVERSION}_amd64.tgz
 
 FROM alpine:latest as tailscale
 ARG TSFILE

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TSFILE=tailscale_${TSVERSION}_amd64.tgz
 FROM alpine:latest as tailscale
 ARG TSFILE
 WORKDIR /app
-#ENV TSFILE=tailscale_1.26.2_amd64.tgz
+
 RUN wget https://pkgs.tailscale.com/stable/${TSFILE} && \
   tar xzf ${TSFILE} --strip-components=1
 COPY . ./


### PR DESCRIPTION
Inspired by <https://github.com/adyanth/openwrt-tailscale-enabler/blob/main/.github/workflows/autoupdate.yml> (basically copy-and-paste lol).

Added a cron job on GitHub action that runs once a week on Sunday to check if there's a new Tailscale stable version.