### PR TITLE
remove unnecessary sleeps

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -15,19 +15,10 @@ ip6tables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 
 # --tun=userspace-networking --socks5-server=localhost:1055
 /app/tailscaled --verbose=1 --port 41641 &
-sleep 5
-if [ ! -S /var/run/tailscale/tailscaled.sock ]; then
-    echo "tailscaled.sock does not exist. exit!"
-    exit 1
-fi
-
-until /app/tailscale up \
+/app/tailscale up \
     --authkey=${TAILSCALE_AUTH_KEY} \
     --hostname=fly-${FLY_REGION} \
     --advertise-exit-node
-do
-    sleep 0.1
-done
 
 echo 'Tailscale started. Lets go!'
 sleep infinity


### PR DESCRIPTION
The `tailscale` client no longer needs the sleeps in order to connect to `tailscaled`. It does the right thing if `tailscaled` is still starting up and waits for it to be ready.

See https://github.com/tailscale/tailscale/commit/21cb0b361fbbb7580fae8f8a01193b3ec361e56a for more details.