### PR TITLE
Remove incorrect ephemeral key assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ In order to use tailscale for exit traffic you need to configure a public DNS. G
 #### 5. Create a tailscale auth key
 Create a reusable auth key in tailscale: https://login.tailscale.com/admin/settings/authkeys
 
-_A ephemeral key would be better for our use case, but it's restricted to IPv6 only by tailscale, which doesn't work so well as a VPN exit node._
-
 
 #### 6. Have a fly.io account and cli
 Install the fly-cli to your machine and login with github: https://fly.io/docs/hands-on/installing/

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ In order to use tailscale for exit traffic you need to configure a public DNS. G
 You have two options for authenticating your Tailscale nodes:
 
 ##### Option A: Create a tailscale auth key (traditional method)
-Create a reusable auth key in tailscale: https://login.tailscale.com/admin/settings/authkeys
+Create an auth key in tailscale: https://login.tailscale.com/admin/settings/authkeys
+
+Choose the following options:
+- `reusable` (for more than one device)
+- `ephemeral` (autoremove if going offline)
 
 ##### Option B: Create an OAuth client (recommended)
 1. Go to your Tailscale admin console: https://login.tailscale.com/admin/settings/oauth


### PR DESCRIPTION
In the README:
> A ephemeral key would be better for our use case, but it's restricted to IPv6 only by tailscale, which doesn't work so well as a VPN exit node.

AFAIK the Tailscale IP is IPv6, but is still accessible from IPv4 addresses from the node's public IPv4. (the underlying transport uses v4/v6 independently of the Tailscale IP.)