### PR TITLE
Update link iptables to iptables-legacy on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,14 @@ COPY . ./
 
 
 FROM alpine:latest
-RUN apk update && apk add ca-certificates iptables ip6tables iproute2 && rm -rf /var/cache/apk/*
+# alpine:3.19 links iptables to iptables-nft https://gitlab.alpinelinux.org/alpine/aports/-/commit/f87a191922955bcf5c5f3fc66a425263a4588d48.
+# iptables-nft requires kernel support for nft, which is currently not available in Fly.io,
+# so we remove the links and ensure that the iptables-legacy version is used.
+RUN apk update && apk add ca-certificates iptables iptables-legacy ip6tables  \
+  && rm -rf /var/cache/apk/* \
+  && rm /sbin/iptables && ln -s /sbin/iptables-legacy /sbin/iptables  \
+  && rm /sbin/ip6tables && ln -s /sbin/ip6tables-legacy /sbin/ip6tables
+
 
 # creating directories for tailscale
 RUN mkdir -p /var/run/tailscale


### PR DESCRIPTION
Based on this commit now alpine default to iptables-nft.
https://gitlab.alpinelinux.org/alpine/aports/-/commit/f87a191922955bcf5c5f3fc66a425263a4588d48

iptables-nft requires kernel support for nft, which is currently not available in Fly.io, so we remove the links and ensure that the iptables-legacy version is used.