### PR TITLE
Add OAuth authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,24 @@ Install tailscale on your machine(s):
 #### 4. Setup DNS in tailscale
 In order to use tailscale for exit traffic you need to configure a public DNS. Go to https://login.tailscale.com/admin/dns and add the nameservers of your choice (eg. cloudflare: `1.1.1.1, 1.0.0.1, 2606:4700:4700::1111, 2606:4700:4700::1001`)
 
-#### 5. Create a tailscale auth key
+#### 5. Authentication Options
+
+You have two options for authenticating your Tailscale nodes:
+
+##### Option A: Create a tailscale auth key (traditional method)
 Create a reusable auth key in tailscale: https://login.tailscale.com/admin/settings/authkeys
 
 _A ephemeral key would be better for our use case, but it's restricted to IPv6 only by tailscale, which doesn't work so well as a VPN exit node._
+
+##### Option B: Create an OAuth client (recommended)
+1. Go to your Tailscale admin console: https://login.tailscale.com/admin/settings/oauth
+2. Create a new OAuth client with the following scopes:
+   - `devices:core`
+   - `auth_keys:write`
+3. Apply the tag `tag:fly-exit` to the OAuth client
+4. Save the client ID and secret for use in step 9
+
+Using OAuth is recommended as it provides more fine-grained access control and is the modern authentication method for Tailscale.
 
 
 #### 6. Have a fly.io account and cli
@@ -85,9 +99,17 @@ fly launch
 ? would you like to deploy now : (yes/no) no
 ```
 
-#### 9. Set the tailscale auth key in fly
+#### 9. Set the Tailscale authentication credentials in fly
+
+##### If using Auth Key (Option A from step 5):
 ```
-fly secrets set TAILSCALE_AUTH_KEY=[see step 4]
+fly secrets set TAILSCALE_AUTH_KEY=[your auth key]
+Secrets are staged for the first deployment
+```
+
+##### If using OAuth (Option B from step 5):
+```
+fly secrets set TAILSCALE_OAUTH_CLIENT_ID=[your OAuth client ID] TAILSCALE_OAUTH_SECRET=[your OAuth client secret]
 Secrets are staged for the first deployment
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ _A ephemeral key would be better for our use case, but it's restricted to IPv6 o
 ##### Option B: Create an OAuth client (recommended)
 1. Go to your Tailscale admin console: https://login.tailscale.com/admin/settings/oauth
 2. Create a new OAuth client with the following scopes:
-   - `devices:core`
+   - `devices:core:write`
    - `auth_keys:write`
 3. Apply the tag `tag:fly-exit` to the OAuth client
 4. Save the client ID and secret for use in step 9

--- a/start.sh
+++ b/start.sh
@@ -22,7 +22,7 @@ ip6tables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 
 # Check if using OAuth or Auth Key
 if [ -n "$TAILSCALE_OAUTH_CLIENT_ID" ] && [ -n "$TAILSCALE_OAUTH_SECRET" ]; then
-    echo "Using OAuth authentication to generate an auth key"
+    echo "Using OAuth to generate an auth key"
     
     # Get an access token using the OAuth client credentials
     OAUTH_TOKEN_RESPONSE=$(wget --quiet --output-document=- --header="Content-Type: application/x-www-form-urlencoded" \
@@ -57,8 +57,7 @@ if [ -n "$TAILSCALE_OAUTH_CLIENT_ID" ] && [ -n "$TAILSCALE_OAUTH_SECRET" ]; then
     /app/tailscale up \
         --auth-key=${AUTH_KEY} \
         --hostname=fly-${FLY_REGION} \
-        --advertise-exit-node #\
-        #--advertise-tags=tag:fly-exit # requires ACL tagOwners
+        --advertise-exit-node
 else
     # Use Auth Key authentication directly
     echo "Using Auth Key authentication"

--- a/start.sh
+++ b/start.sh
@@ -20,11 +20,23 @@ ip6tables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
     #--tun=userspace-networking
     #--socks5-server=localhost:1055
 
-/app/tailscale up \
-    --authkey=${TAILSCALE_AUTH_KEY} \
-    --hostname=fly-${FLY_REGION} \
-    --advertise-exit-node #\
-    #--advertise-tags=tag:fly-exit # requires ACL tagOwners
+# Check if using OAuth or Auth Key
+if [ -n "$TAILSCALE_OAUTH_CLIENT_ID" ] && [ -n "$TAILSCALE_OAUTH_SECRET" ]; then
+    # Use OAuth authentication
+    /app/tailscale up \
+        --oauth-client-id=${TAILSCALE_OAUTH_CLIENT_ID} \
+        --oauth-client-secret=${TAILSCALE_OAUTH_SECRET} \
+        --hostname=fly-${FLY_REGION} \
+        --advertise-exit-node #\
+        #--advertise-tags=tag:fly-exit # requires ACL tagOwners
+else
+    # Use Auth Key authentication
+    /app/tailscale up \
+        --authkey=${TAILSCALE_AUTH_KEY} \
+        --hostname=fly-${FLY_REGION} \
+        --advertise-exit-node #\
+        #--advertise-tags=tag:fly-exit # requires ACL tagOwners
+fi
 
 echo "Tailscale started. Let's go!"
 sleep infinity


### PR DESCRIPTION
This PR adds support for OAuth client authentication as an alternative to auth keys. It includes:

- Documentation on how to create and configure OAuth clients in Tailscale
- Updated start.sh script to use the Tailscale API to automatically generate auth keys
- Option to fall back to direct auth key authentication
- Updated README with setup instructions for both authentication methods

OAuth authentication provides more fine-grained access control compared to auth keys and is the recommended authentication method by Tailscale.

The implementation uses OAuth client credentials to:
1. Obtain an access token from the Tailscale API
2. Generate a pre-authorized, reusable auth key with the right tags
3. Use this auth key to register the device