### PR TITLE
feat: healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN wget https://pkgs.tailscale.com/stable/${TSFILE} && \
 COPY . ./
 
 FROM alpine:latest
-RUN apk update && apk add ca-certificates iptables ip6tables \
+# busybox-extras provides httpd, used to serve the health check endpoint (see start.sh)
+RUN apk update && apk add ca-certificates iptables ip6tables busybox-extras \
   && rm -rf /var/cache/apk/*
 
 # creating directories for tailscale
@@ -18,10 +19,15 @@ RUN mkdir -p /var/run/tailscale
 RUN mkdir -p /var/cache/tailscale
 RUN mkdir -p /var/lib/tailscale
 
+# directory served by httpd for the health check endpoint
+RUN mkdir -p /var/www/cgi-bin
+
 # Copy binary to production image
 COPY --from=tailscale /app/tailscaled /app/tailscaled
 COPY --from=tailscale /app/tailscale /app/tailscale
 COPY --from=tailscale /app/start.sh /app/start.sh
+COPY --from=tailscale /app/healthz /var/www/cgi-bin/healthz
+RUN chmod +x /var/www/cgi-bin/healthz
 
 # Run on container startup.
 USER root

--- a/fly.toml
+++ b/fly.toml
@@ -18,7 +18,22 @@ kill_timeout = "5s"
 
   [[services.ports]]
     port = 41641
+
   [services.concurrency]
     type = "connections"
     hard_limit = 100
     soft_limit = 75
+
+# Machine-level health check. A top-level [checks] block is required here because
+# it lets us probe a custom port (9002): [[services.http_checks]] always targets
+# the service's internal_port (41641/udp), which has no TCP listener.
+# see start.sh and the healthz CGI script.
+[checks]
+  [checks.health]
+    type = "http"
+    port = 9002
+    method = "get"
+    path = "/cgi-bin/healthz"
+    interval = "15s"
+    timeout = "2s"
+    grace_period = "30s"

--- a/healthz
+++ b/healthz
@@ -1,0 +1,15 @@
+#!/bin/sh
+# CGI health endpoint, served by busybox httpd (started in start.sh).
+# Fly's health check (see [checks] in fly.toml) requests /cgi-bin/healthz on
+# port 9002 and expects a 2xx response.
+#
+# We can't use Tailscale's built-in TS_ENABLE_HEALTH_CHECK because that's a
+# containerboot feature of the official image; this repo runs raw tailscaled.
+#
+# Returns 200 only when the node is actually connected to the tailnet, and 503
+# otherwise (e.g. tailscaled crashed or was OOM-killed, or auth failed).
+if /app/tailscale status --json 2>/dev/null | grep -Eq '"BackendState":[[:space:]]*"Running"'; then
+  printf 'Status: 200 OK\r\nContent-Type: text/plain\r\n\r\nok\n'
+else
+  printf 'Status: 503 Service Unavailable\r\nContent-Type: text/plain\r\n\r\nunhealthy\n'
+fi

--- a/start.sh
+++ b/start.sh
@@ -20,6 +20,10 @@ ip6tables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
     #--tun=userspace-networking
     #--socks5-server=localhost:1055
 
+# Serve the health check endpoint for Fly's [checks] http check (see fly.toml).
+# /cgi-bin/healthz
+httpd -f -p 9002 -h /var/www &
+
 # Check if using OAuth or Auth Key
 if [ -n "$TAILSCALE_OAUTH_CLIENT_ID" ] && [ -n "$TAILSCALE_OAUTH_SECRET" ]; then
     echo "Using OAuth to generate an auth key"


### PR DESCRIPTION
Serve /cgi-bin/healthz via busybox httpd, returning 200 when the node is connected to the tailnet and 503 otherwise, and probe it from a top-level [checks] block on port 9002.

Raw tailscaled doesn't honor TS_ENABLE_HEALTH_CHECK (a containerboot feature).