### PR TITLE
feat: docker image

### DIFF
--- a/.github/scripts/prune-ghcr.sh
+++ b/.github/scripts/prune-ghcr.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env sh
+# Keep the most-recent tagged releases of the image and delete the rest, so the
+# GHCR package retains pinnable :<tailscale-version> tags (and :latest) for
+# rollback without growing without bound.
+#
+# Why a custom script instead of an off-the-shelf "delete untagged versions":
+# a release is several package versions. With provenance + SBOM the release is
+# an index whose child manifests (image + the provenance/SBOM attestation) are
+# *untagged* versions, and cosign stores its signature as a separate artifact
+# tagged after the subject digest -- sha256-<hex> (OCI 1.1 referrers fallback)
+# or the legacy sha256-<hex>.sig -- which itself references an untagged
+# signature manifest. To keep a release usable we must keep all of these; to
+# drop one we must delete all of them. So we resolve each kept release to the
+# exact set of digests that belong to it and delete everything outside that set.
+#
+# Env:
+#   IMAGE         image ref without tag, e.g. ghcr.io/patte/fly-tailscale-exit
+#   OWNER         GHCR owner (user/org) that owns the package
+#   PACKAGE       package name, e.g. fly-tailscale-exit
+#   MAX_VERSIONS  most-recent tagged releases to keep (default 25; 0 deletes all)
+#   GH_TOKEN      token with packages:write on the package (GITHUB_TOKEN is
+#                 enough when the package inherits access from this repo;
+#                 otherwise a PAT with delete:packages)
+set -eu
+
+: "${IMAGE:?}"
+: "${OWNER:?}"
+: "${PACKAGE:?}"
+: "${GH_TOKEN:?}"
+MAX_VERSIONS="${MAX_VERSIONS:-25}"
+
+api="/users/${OWNER}/packages/container/${PACKAGE}/versions"
+tab="$(printf '\t')"
+
+# Every version: id, digest (.name), created_at, comma-joined tags.
+all="$(mktemp)"
+gh api --paginate "$api" \
+  -q '.[] | [.id, .name, .created_at, ((.metadata.container.tags // []) | join(","))] | @tsv' \
+  >"$all"
+
+# A cosign artifact tag is the subject digest rewritten as sha256-<hex>, with an
+# optional legacy .sig/.att/.sbom suffix. Such a tag is never a release tag.
+sig_re='^sha256-[0-9a-f]+(\.(sig|att|sbom))?$'
+
+# Releases = tagged versions that are not cosign artifacts, newest first by
+# creation time (ISO-8601 sorts lexically == chronologically). Keep the digests
+# of the MAX_VERSIONS most-recent (:latest is the newest push, always included).
+keep_indexes="$(mktemp)"
+awk -F"$tab" -v re="$sig_re" 'NF>=4 && $4 != "" && $4 !~ re' "$all" \
+  | sort -t"$tab" -k3,3r \
+  | awk -F"$tab" -v n="$MAX_VERSIONS" 'NR<=n { print $2 }' \
+  >"$keep_indexes"
+
+# Cosign artifacts as "tag<TAB>digest", for referrers lookup by subject digest.
+sigmap="$(mktemp)"
+awk -F"$tab" -v re="$sig_re" 'NF>=4 && $4 ~ re { print $4 "\t" $2 }' "$all" >"$sigmap"
+
+# Build the keep set: each kept release, the child manifests it references
+# (image + provenance/SBOM attestation; `[]?` no-ops for a plain manifest), and
+# the cosign artifact covering it plus that artifact's own child manifest(s).
+keep="$(mktemp)"
+while IFS= read -r d; do
+  printf '%s\n' "$d"
+  docker buildx imagetools inspect --raw "${IMAGE}@${d}" | jq -r '.manifests[]?.digest'
+  want="sha256-${d#sha256:}"
+  sdig="$(awk -F"$tab" -v w="$want" '$1 == w || $1 == w ".sig" { print $2; exit }' "$sigmap")"
+  if [ -n "$sdig" ]; then
+    printf '%s\n' "$sdig"
+    docker buildx imagetools inspect --raw "${IMAGE}@${sdig}" | jq -r '.manifests[]?.digest'
+  fi
+done <"$keep_indexes" >>"$keep"
+
+sort -u -o "$keep" "$keep"
+
+echo "Keeping $(wc -l <"$keep_indexes") release(s) + children + signatures = $(wc -l <"$keep") manifest(s) (max ${MAX_VERSIONS} releases)."
+
+# Delete everything outside the keep set: releases beyond MAX_VERSIONS, the
+# children and signatures of those dropped releases, and any stray untagged
+# orphans (e.g. a digest a tag was moved off of).
+deleted=0
+while IFS="$tab" read -r id digest _ tags; do
+  if grep -qxF "$digest" "$keep"; then
+    continue
+  fi
+  echo "Deleting $digest (id $id, tags: ${tags:-<none>})"
+  gh api --method DELETE "${api}/${id}"
+  deleted=$((deleted + 1))
+done <"$all"
+
+echo "Prune complete; deleted ${deleted} version(s)."

--- a/.github/scripts/prune-ghcr.sh
+++ b/.github/scripts/prune-ghcr.sh
@@ -17,7 +17,8 @@
 #   IMAGE         image ref without tag, e.g. ghcr.io/patte/fly-tailscale-exit
 #   OWNER         GHCR owner (user/org) that owns the package
 #   PACKAGE       package name, e.g. fly-tailscale-exit
-#   MAX_VERSIONS  most-recent tagged releases to keep (default 25; 0 deletes all)
+#   MAX_VERSIONS  most-recent tagged releases to keep (default 25; 0 targets all,
+#                 but GHCR won't let the API delete a package's last version)
 #   GH_TOKEN      token with packages:write on the package (GITHUB_TOKEN is
 #                 enough when the package inherits access from this repo;
 #                 otherwise a PAT with delete:packages)
@@ -55,7 +56,9 @@ sig_re='^sha256-[0-9a-f]+(\.(sig|att|sbom))?$'
 
 # Releases = tagged versions that are not cosign artifacts, newest first by
 # creation time (ISO-8601 sorts lexically == chronologically). Keep the digests
-# of the MAX_VERSIONS most-recent (:latest is the newest push, always included).
+# of the MAX_VERSIONS most-recent; the newest push carries :latest, so it's kept
+# whenever MAX_VERSIONS>=1. (MAX_VERSIONS=0 keeps none and targets every version,
+# but GHCR won't delete a package's last remaining one, so one always survives.)
 keep_indexes="$(mktemp)"
 awk -F"$tab" -v re="$sig_re" 'NF>=4 && $4 != "" && $4 !~ re' "$all" \
   | sort -t"$tab" -k3,3r \

--- a/.github/scripts/prune-ghcr.sh
+++ b/.github/scripts/prune-ghcr.sh
@@ -35,7 +35,12 @@ IMAGE="$(printf '%s' "$IMAGE" | tr '[:upper:]' '[:lower:]')"
 OWNER="$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]')"
 PACKAGE="$(printf '%s' "$PACKAGE" | tr '[:upper:]' '[:lower:]')"
 
-api="/users/${OWNER}/packages/container/${PACKAGE}/versions"
+# Packages live under /users/<user> or /orgs/<org>; GET /users/<owner> reports the type for both
+if [ "$(gh api "/users/${OWNER}" -q .type 2>/dev/null)" = "Organization" ]; then
+  api="/orgs/${OWNER}/packages/container/${PACKAGE}/versions"
+else
+  api="/users/${OWNER}/packages/container/${PACKAGE}/versions"
+fi
 tab="$(printf '\t')"
 
 # Every version: id, digest (.name), created_at, comma-joined tags.

--- a/.github/scripts/prune-ghcr.sh
+++ b/.github/scripts/prune-ghcr.sh
@@ -29,6 +29,12 @@ set -eu
 : "${GH_TOKEN:?}"
 MAX_VERSIONS="${MAX_VERSIONS:-25}"
 
+# GHCR refs and package names are lowercase; the caller may pass them straight
+# from ${{ github.repository }} etc., which can contain uppercase on some forks.
+IMAGE="$(printf '%s' "$IMAGE" | tr '[:upper:]' '[:lower:]')"
+OWNER="$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]')"
+PACKAGE="$(printf '%s' "$PACKAGE" | tr '[:upper:]' '[:lower:]')"
+
 api="/users/${OWNER}/packages/container/${PACKAGE}/versions"
 tab="$(printf '\t')"
 

--- a/.github/workflows/auto-update-tailscale.yml
+++ b/.github/workflows/auto-update-tailscale.yml
@@ -7,10 +7,12 @@ on:
   workflow_dispatch:
 
 # contents: write to push the version-bump commit; issues: write to open a
-# failure issue (see the last step).
+# failure issue (see the last step); actions: write to dispatch the publish
+# workflow after a bump (a GITHUB_TOKEN push can't trigger it directly).
 permissions:
   contents: write
   issues: write
+  actions: write
 
 jobs:
   update_tailscale:
@@ -54,6 +56,15 @@ jobs:
           git add Dockerfile
           git commit -m "chore: auto update tailscale to ${{ steps.bump.outputs.version }}"
           git push
+
+      # A push made with GITHUB_TOKEN does not trigger other workflows, so start
+      # the publish explicitly. workflow_dispatch via the API is exempt from that
+      # rule, so this needs no PAT — just actions: write above.
+      - name: Trigger image publish
+        if: steps.bump.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run publish.yml --ref main
 
       # A weekly scheduled run that goes red is easy to miss, so surface failures
       # explicitly. De-dupe: comment on the existing open issue rather than

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Shellcheck scripts
-        run: shellcheck -s sh start.sh healthz .github/scripts/smoke-test.sh
+        run: shellcheck -s sh start.sh healthz .github/scripts/smoke-test.sh .github/scripts/prune-ghcr.sh
 
       - name: Hadolint Dockerfile
         # Run hadolint's image directly (digest-pinned) rather than the

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,11 @@
 name: Publish image
 
-# Publishes ghcr.io/<owner>/fly-tailscale-exit as :latest and :<tailscale-version>
-# Each run rebuilds, then prunes to the most-recent tagged releases, so the package keeps
-# pinnable versions for rollback without accumulating dead images, provenance,
-# or SBOM manifests.
+# Publishes ghcr.io/<owner>/<repo> as :latest and :<tailscale-version> so the
+# image can be deployed without cloning (`fly deploy -i ...`). Each run rebuilds,
+# then prunes to the most-recent tagged releases, so the package keeps pinnable
+# versions for rollback without accumulating dead images, provenance, or SBOM
+# manifests. Structure follows GitHub's docker-publish starter template; the
+# additions are the version-derived tag, the smoke-test gate, and the prune.
 
 on:
   push:
@@ -25,6 +27,10 @@ on:
     - cron: "0 6 * * 3"
   workflow_dispatch:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 # packages: write to push to and prune GHCR; contents: read to checkout;
 # id-token: write for cosign keyless signing (Sigstore/Fulcio OIDC challenge).
 permissions:
@@ -44,20 +50,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Resolve image ref and tailscale version
-        id: meta
-        run: |
-          # Name the image after the repo (GHCR requires a lowercase ref), so
-          # forks/test repos get their own package instead of colliding.
-          repo=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          # The tailscale version pinned in the Dockerfile becomes the image tag.
-          version=$(sed -n '1s/^ARG TSVERSION=//p' Dockerfile)
-          {
-            echo "owner=${repo%%/*}"
-            echo "package=${repo#*/}"
-            echo "image=ghcr.io/$repo"
-            echo "version=$version"
-          } >>"$GITHUB_OUTPUT"
+      # The tailscale version pinned in the Dockerfile becomes the image tag.
+      - name: Read tailscale version
+        id: ver
+        run: echo "version=$(sed -n '1s/^ARG TSVERSION=//p' Dockerfile)" >>"$GITHUB_OUTPUT"
 
       # Gate the publish on the same behavioural check CI runs: build the image
       # and confirm healthz serves 503 without auth. If this fails the job stops
@@ -71,7 +67,7 @@ jobs:
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -81,17 +77,18 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.1.2
 
-      # OCI labels so GHCR links the package back to this repo and shows
-      # source/revision/created. We only consume the labels output; tags are set
-      # explicitly on the build step below (our version axis is the tailscale
-      # version, not a git tag).
-      - name: Docker metadata (labels)
-        id: labels
+      # Tags (:latest + :<tailscale-version>) and OCI labels. metadata-action
+      # lowercases the image name and links the package back to this repo.
+      - name: Docker metadata
+        id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ steps.meta.outputs.image }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ steps.ver.outputs.version }}
 
-      - name: Build and push :latest and :<tailscale-version>
+      - name: Build and push
         id: build
         uses: docker/build-push-action@v6
         with:
@@ -100,32 +97,30 @@ jobs:
           # runs amd64.
           platforms: linux/amd64
           push: true
-          tags: |
-            ${{ steps.meta.outputs.image }}:latest
-            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
-          labels: ${{ steps.labels.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           provenance: true
           sbom: true
 
       # Keyless-sign by digest (covers both tags, which share it). Writes the
-      # signature to GHCR as a sha256-<digest>.sig artifact and logs the
-      # certificate to the public Rekor transparency log. The prune step is
-      # signature-aware: it keeps each kept release's .sig and drops the rest.
+      # signature to GHCR as a cosign artifact and logs the certificate to the
+      # public Rekor transparency log. The prune step is signature-aware: it
+      # keeps each kept release's signature and drops the rest.
       - name: Sign the image (keyless)
         env:
-          IMAGE: ${{ steps.meta.outputs.image }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DIGEST: ${{ steps.build.outputs.digest }}
         run: cosign sign --yes "${IMAGE}@${DIGEST}"
 
-      # Keep the most-recent tagged releases (and their provenance/SBOM
-      # children) and delete the rest, so :<version> pins stay available for
-      # rollback without the package growing forever. See the script for why
+      # Keep the most-recent tagged releases (and their provenance/SBOM children
+      # and signatures) and delete the rest, so :<version> pins stay available
+      # for rollback without the package growing forever. See the script for why
       # this beats the off-the-shelf "delete untagged" actions.
       - name: Prune old releases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGE: ${{ steps.meta.outputs.image }}
-          OWNER: ${{ steps.meta.outputs.owner }}
-          PACKAGE: ${{ steps.meta.outputs.package }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: ${{ github.event.repository.name }}
           MAX_VERSIONS: "25"
         run: ./.github/scripts/prune-ghcr.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,131 @@
+name: Publish image
+
+# Publishes ghcr.io/<owner>/fly-tailscale-exit as :latest and :<tailscale-version>
+# Each run rebuilds, then prunes to the most-recent tagged releases, so the package keeps
+# pinnable versions for rollback without accumulating dead images, provenance,
+# or SBOM manifests.
+
+on:
+  push:
+    branches: [main]
+    # Only the inputs that change the image (or this pipeline itself). The weekly
+    # tailscale auto-update commits a Dockerfile bump to main, so that republishes
+    # automatically.
+    paths:
+      - Dockerfile
+      - start.sh
+      - healthz
+      - .github/workflows/publish.yml
+      - .github/scripts/prune-ghcr.sh
+  # Weekly rebuild to pick up alpine base-image patches: the Dockerfile pins
+  # alpine by tag (not digest), so a patch release within 3.23 never changes a
+  # tracked file and would otherwise never be rebuilt. Offset from the Sunday
+  # 00:00 tailscale auto-update.
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+# packages: write to push to and prune GHCR; contents: read to checkout;
+# id-token: write for cosign keyless signing (Sigstore/Fulcio OIDC challenge).
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+# Serialize runs so two publishes never race each other's tag moves or prune.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: build, push & prune
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve image ref and tailscale version
+        id: meta
+        run: |
+          # Name the image after the repo (GHCR requires a lowercase ref), so
+          # forks/test repos get their own package instead of colliding.
+          repo=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          # The tailscale version pinned in the Dockerfile becomes the image tag.
+          version=$(sed -n '1s/^ARG TSVERSION=//p' Dockerfile)
+          {
+            echo "owner=${repo%%/*}"
+            echo "package=${repo#*/}"
+            echo "image=ghcr.io/$repo"
+            echo "version=$version"
+          } >>"$GITHUB_OUTPUT"
+
+      # Gate the publish on the same behavioural check CI runs: build the image
+      # and confirm healthz serves 503 without auth. If this fails the job stops
+      # before the push below, so a broken image is never published. (Cheap to
+      # build twice — the image is just alpine + a tailscale tarball.)
+      - name: Build and smoke test
+        run: |
+          docker build -t fly-tailscale-exit:smoke .
+          ./.github/scripts/smoke-test.sh fly-tailscale-exit:smoke
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      # OCI labels so GHCR links the package back to this repo and shows
+      # source/revision/created. We only consume the labels output; tags are set
+      # explicitly on the build step below (our version axis is the tailscale
+      # version, not a git tag).
+      - name: Docker metadata (labels)
+        id: labels
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.meta.outputs.image }}
+
+      - name: Build and push :latest and :<tailscale-version>
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          # amd64 only: the Dockerfile pulls the amd64 tailscale tarball and Fly
+          # runs amd64.
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image }}:latest
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
+          labels: ${{ steps.labels.outputs.labels }}
+          provenance: true
+          sbom: true
+
+      # Keyless-sign by digest (covers both tags, which share it). Writes the
+      # signature to GHCR as a sha256-<digest>.sig artifact and logs the
+      # certificate to the public Rekor transparency log. The prune step is
+      # signature-aware: it keeps each kept release's .sig and drops the rest.
+      - name: Sign the image (keyless)
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      # Keep the most-recent tagged releases (and their provenance/SBOM
+      # children) and delete the rest, so :<version> pins stay available for
+      # rollback without the package growing forever. See the script for why
+      # this beats the off-the-shelf "delete untagged" actions.
+      - name: Prune old releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE: ${{ steps.meta.outputs.image }}
+          OWNER: ${{ steps.meta.outputs.owner }}
+          PACKAGE: ${{ steps.meta.outputs.package }}
+          MAX_VERSIONS: "25"
+        run: ./.github/scripts/prune-ghcr.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,10 @@ on:
       - .github/scripts/prune-ghcr.sh
   # Weekly rebuild to pick up alpine base-image patches: the Dockerfile pins
   # alpine by tag (not digest), so a patch release within 3.23 never changes a
-  # tracked file and would otherwise never be rebuilt. Offset from the Sunday
-  # 00:00 tailscale auto-update.
+  # tracked file and would otherwise never be rebuilt. Mid-week, spaced away
+  # from the Sunday 00:00 tailscale auto-update (which triggers its own publish).
   schedule:
-    - cron: "0 6 * * 1"
+    - cron: "0 6 * * 3"
   workflow_dispatch:
 
 # packages: write to push to and prune GHCR; contents: read to checkout;

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Features:
   - returns `200` when the node is connected to the tailnet, `503` otherwise
 - [x] self-healing: the container exits if `tailscaled` dies, so Fly restarts the machine
 - [x] CI: `shellcheck`, `hadolint`, image build, and a no-secrets `healthz` smoke test
+- [x] published to GHCR as a cosign-signed image (SLSA provenance + SBOM), so you can deploy without cloning
 - [x] weekly GitHub Action to auto-update `tailscale`, gated on CI, opening an issue on failure
 - [x] Dependabot for the base image and GitHub Actions
 
@@ -50,6 +51,43 @@ tailscale set --exit-node=fly-<region>
 ```
 
 Add more regions with `fly scale count 1 --region fra` (see step 13 below).
+
+## Even quicker: deploy straight from the image (no clone)
+
+Every change publishes a signed image to the GitHub Container Registry, so the fastest start is a few CLI commands — no clone, no Dockerfile, no `fly.toml`, no files at all:
+
+```bash
+fly apps create my-exit-node        # pick a unique name; creates no fly.toml
+fly secrets set -a my-exit-node \
+  TAILSCALE_OAUTH_CLIENT_ID=<id> TAILSCALE_OAUTH_SECRET=<secret>   # or TAILSCALE_AUTH_KEY=<key>
+fly machine run ghcr.io/patte/fly-tailscale-exit:latest -a my-exit-node --region fra
+```
+
+Approve the `fly-<region>` node in the [admin console](https://login.tailscale.com/admin/machines), then activate the exit node (`tailscale set --exit-node=fly-<region>`). Traffic may relay via Tailscale's [DERP](https://tailscale.com/kb/1232/derp-servers) servers.
+
+<details>
+<summary>Direct peer-to-peer, a managed app (fly.toml), image tags, and verifying the signature</summary>
+
+**Direct, peer-to-peer connections** — expose the UDP port, which on Fly needs a dedicated IPv4 (UDP can't use the free shared IPv4 or IPv6; ~$2/mo):
+
+```bash
+fly ips allocate-v4 -a my-exit-node
+fly machine run ghcr.io/patte/fly-tailscale-exit:latest -a my-exit-node --region fra --port 41641/udp
+```
+
+**For a more advanced setup** — health checks and easy scaling across regions — use the [Quickstart](#quickstart) clone; uncomment the `image =` line in its [`fly.toml`](fly.toml) to deploy this prebuilt image instead of building.
+
+**Tags** — `:latest` tracks the newest tailscale release; `:<tailscale-version>` (e.g. `:1.98.4`) pins one. The image is `linux/amd64`, rebuilt weekly for `alpine` base-image patches, and the 25 most recent versions are kept.
+
+**Verify the signature** — the image is keyless-signed with [cosign](https://docs.sigstore.dev/) and carries SLSA provenance + an SBOM:
+
+```bash
+cosign verify ghcr.io/patte/fly-tailscale-exit:latest \
+  --certificate-identity-regexp '^https://github.com/patte/fly-tailscale-exit/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+</details>
 
 ## Alternative: the official Tailscale image
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Secrets are staged for the first deployment
 fly deploy
 ? Would you like to allocate a dedicated ipv4 address now? No
 ```
-Answer **No** — you don't need a dedicated IPv4. Tailscale hole-punches a **direct** path through Fly's (endpoint-independent) NAT on its own, so a dedicated IPv4 does not improve connectivity for an exit node. (Verified: `tailscaled` advertises the machine's egress IP, never the Fly ingress IP, so the paid IP simply goes unused — which is why this `fly.toml` carries no `[[services]]` block.)
+Answer **No** — a dedicated IPv4 can't improve P2P for an exit node, for two reasons. (1) Fly's egress NAT is endpoint-independent, so Tailscale hole-punches a **direct** path for free. (2) Even if you wanted the paid IP, `tailscaled` only advertises the machine's *egress* IP (via STUN), never Fly's *ingress* Anycast IP, so it's never reachable as an endpoint anyway ([#8862](https://github.com/tailscale/tailscale/issues/8862)). (Exposing a public UDP port *is* the standard fix on symmetric-NAT clouds like AWS/Azure — Fly just isn't one.) Hence no `[[services]]` block in this `fly.toml` and no need to allocate a dedicated IPv4.
 
 > Whether a given client gets a direct connection or falls back to Tailscale [DERP](https://tailscale.com/kb/1232/derp-servers) relays depends on the **client's** network: most home/office networks hole-punch straight to direct; hard CGNAT or some mobile hotspots stay on DERP (still works, just relayed). Nothing on the Fly node changes this.
 

--- a/README.md
+++ b/README.md
@@ -63,17 +63,10 @@ fly secrets set -a my-exit-node \
 fly machine run ghcr.io/patte/fly-tailscale-exit:latest -a my-exit-node --region fra
 ```
 
-Approve the `fly-<region>` node in the [admin console](https://login.tailscale.com/admin/machines), then activate the exit node (`tailscale set --exit-node=fly-<region>`). Traffic may relay via Tailscale's [DERP](https://tailscale.com/kb/1232/derp-servers) servers.
+Approve the `fly-<region>` node in the [admin console](https://login.tailscale.com/admin/machines), then activate the exit node (`tailscale set --exit-node=fly-<region>`). On most networks Tailscale hole-punches a **direct** connection through Fly's NAT; restrictive client NATs (hard CGNAT, some mobile hotspots) fall back to [DERP](https://tailscale.com/kb/1232/derp-servers) relays.
 
 <details>
-<summary>Direct peer-to-peer, a managed app (fly.toml), image tags, and verifying the signature</summary>
-
-**Direct, peer-to-peer connections** — expose the UDP port, which on Fly needs a dedicated IPv4 (UDP can't use the free shared IPv4 or IPv6; ~$2/mo):
-
-```bash
-fly ips allocate-v4 -a my-exit-node
-fly machine run ghcr.io/patte/fly-tailscale-exit:latest -a my-exit-node --region fra --port 41641/udp
-```
+<summary>A managed app (fly.toml), image tags, and verifying the signature</summary>
 
 **For a more advanced setup** — health checks and easy scaling across regions — use the [Quickstart](#quickstart) clone; uncomment the `image =` line in its [`fly.toml`](fly.toml) to deploy this prebuilt image instead of building.
 
@@ -100,7 +93,7 @@ Well, why not run it "yourself"? This guide helps you to set up a globally distr
 - Instantly scale up or down nodes around the planet
 - Choose where your traffic exits to the internet from [30+ locations](https://fly.io/docs/reference/regions/).
 - Enjoy solid connections worldwide
-- ~~Bonus: the setup and the first 160GB of traffic each month are gratis.~~ _Update_: a dedicated IPv4 to enable P2P communication (not via DERP) now [costs $2/mo](https://fly.io/docs/about/pricing/#anycast-ip-addresses). _Update 2_: Fly.io's free tier (160/140GB) isn't meant for use by proxies. Your fly plan might get [upgraded to a $10/month “Advanced” plan](https://community.fly.io/t/4896). Thanks [@ignoramous](https://github.com/patte/fly-tailscale-exit/issues/37) for the heads up.
+- ~~Bonus: the setup and the first 160GB of traffic each month are gratis.~~ _Update_: ~~a dedicated IPv4 to enable P2P communication (not via DERP) now costs $2/mo~~ — peer-to-peer actually works for free via Tailscale's [NAT traversal](https://tailscale.com/blog/how-nat-traversal-works/); no dedicated IPv4 is needed (verified — it goes unused). _Update 2_: Fly.io's free tier (160/140GB) isn't meant for use by proxies. Your fly plan might get [upgraded to a $10/month “Advanced” plan](https://community.fly.io/t/4896). Thanks [@ignoramous](https://github.com/patte/fly-tailscale-exit/issues/37) for the heads up.
 
 
 Sounds too good to be true. Well that's probably because it is. I compiled this setup as an excercise while exploring the capabilities of fly.io and tailscale. This is probably not what you should use as a serious VPN replacement. Go to one of the few trustworthy providers. For the reasons why this is a bad idea, read [below](#user-content-why-this-probably-is-a-bad-idea).
@@ -199,17 +192,15 @@ fly secrets set TAILSCALE_OAUTH_CLIENT_ID=[your OAuth client ID] TAILSCALE_OAUTH
 Secrets are staged for the first deployment
 ```
 
-#### 10 Deploy (and IP and scale)
+#### 10 Deploy (and scale)
 
 ```
 fly deploy
-? Would you like to allocate a dedicated ipv4 address now? Yes
+? Would you like to allocate a dedicated ipv4 address now? No
 ```
-_Update_: fly.io does [not automatically allocate a dedicated IPv4 per app on the first deployment anymore](https://community.fly.io/t/announcement-shared-anycast-ipv4/9384). You want a dedicated IPv4 to be able to expose the UDP port on it and thus enable peer-to-peer connections (not via tailscale DERP). You have three options:
-- Say yes during the initial deploy.
-- Run the command `fly ips allocate-v4` to add a dedicated IPv4 later
-- Run `fly ips allocate-v6`. Direct connections to the node will only work if your local machine has a global IPv6. (not tested) 
-- Remove the `services.ports` section from fly.toml. This has the disadvantage that your node is never going to be directly reachable and all your traffic is routed via tailscale DERP servers.
+Answer **No** — you don't need a dedicated IPv4. Tailscale hole-punches a **direct** path through Fly's (endpoint-independent) NAT on its own, so a dedicated IPv4 does not improve connectivity for an exit node. (Verified: `tailscaled` advertises the machine's egress IP, never the Fly ingress IP, so the paid IP simply goes unused — which is why this `fly.toml` carries no `[[services]]` block.)
+
+> Whether a given client gets a direct connection or falls back to Tailscale [DERP](https://tailscale.com/kb/1232/derp-servers) relays depends on the **client's** network: most home/office networks hole-punch straight to direct; hard CGNAT or some mobile hotspots stay on DERP (still works, just relayed). Nothing on the Fly node changes this.
 
 At the time of writing fly deploys two machines per default. For this setup you probably want 1 machine per region. Run the following to remove the second machine:
 ```

--- a/README.md
+++ b/README.md
@@ -25,9 +25,39 @@ Features:
 > In September 2023 [Tailscale](https://tailscale.com/blog/mullvad-integration) and [Mullvad](https://mullvad.net/en/blog/tailscale-has-partnered-with-mullvad) announced to partner up: for $5/month you can use a mullvad exit node from up to 5 tailscale nodes. This is great news and I'd recommend to use this instead of the setup described here. Follow [this guide](https://tailscale.com/kb/1258/mullvad-exit-nodes) to set it up.
 
 
-## Quickstart
+## Ultra-quickstart
 
 It assumes you have the [`fly` CLI](https://fly.io/docs/hands-on/installing/) installed and a Tailscale tailnet with public DNS configured. The full walkthrough (GitHub org, ACLs, `tag:fly-exit`, regions) is under [Setup](#setup) below.
+
+Every change publishes a signed image to the GitHub Container Registry, so the fastest start is a few CLI commands:
+
+```bash
+fly apps create fly-exit-node        # pick a unique name; creates no fly.toml
+fly secrets set -a fly-exit-node \
+  TAILSCALE_OAUTH_CLIENT_ID=<id> TAILSCALE_OAUTH_SECRET=<secret>   # or TAILSCALE_AUTH_KEY=<key>
+fly machine run ghcr.io/patte/fly-tailscale-exit:latest -a fly-exit-node --region fra
+```
+
+Approve the `fly-<region>` node in the [admin console](https://login.tailscale.com/admin/machines), then activate the exit node (`tailscale set --exit-node=fly-<region>`). On most networks Tailscale hole-punches a **direct** connection through Fly's NAT; restrictive client NATs (hard CGNAT, some mobile hotspots) fall back to [DERP](https://tailscale.com/kb/1232/derp-servers) relays.
+
+<details>
+<summary>Image tags and verifying the signature</summary>
+
+**Tags** — `:latest` tracks the newest tailscale release; `:<tailscale-version>` (e.g. `:1.98.4`) pins one. The image is `linux/amd64`, rebuilt weekly for `alpine` base-image patches, and the 25 most recent versions are kept.
+
+**Verify the signature** — the image is keyless-signed with [cosign](https://docs.sigstore.dev/) and carries SLSA provenance + an SBOM:
+
+```bash
+cosign verify ghcr.io/patte/fly-tailscale-exit:latest \
+  --certificate-identity-regexp '^https://github.com/patte/fly-tailscale-exit/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+</details>
+
+## Quickstart
+
+Prefer your own [`fly.toml`](fly.toml) — health checks, easy multi-region scaling, and a build from source instead of the prebuilt image? Clone and deploy:
 
 ```bash
 git clone https://github.com/patte/fly-tailscale-exit.git
@@ -50,37 +80,7 @@ The node appears as `fly-<region>` in the [Tailscale admin](https://login.tailsc
 tailscale set --exit-node=fly-<region>
 ```
 
-Add more regions with `fly scale count 1 --region fra` (see step 13 below).
-
-## Even quicker: deploy straight from the image (no clone)
-
-Every change publishes a signed image to the GitHub Container Registry, so the fastest start is a few CLI commands — no clone, no Dockerfile, no `fly.toml`, no files at all:
-
-```bash
-fly apps create my-exit-node        # pick a unique name; creates no fly.toml
-fly secrets set -a my-exit-node \
-  TAILSCALE_OAUTH_CLIENT_ID=<id> TAILSCALE_OAUTH_SECRET=<secret>   # or TAILSCALE_AUTH_KEY=<key>
-fly machine run ghcr.io/patte/fly-tailscale-exit:latest -a my-exit-node --region fra
-```
-
-Approve the `fly-<region>` node in the [admin console](https://login.tailscale.com/admin/machines), then activate the exit node (`tailscale set --exit-node=fly-<region>`). On most networks Tailscale hole-punches a **direct** connection through Fly's NAT; restrictive client NATs (hard CGNAT, some mobile hotspots) fall back to [DERP](https://tailscale.com/kb/1232/derp-servers) relays.
-
-<details>
-<summary>A managed app (fly.toml), image tags, and verifying the signature</summary>
-
-**For a more advanced setup** — health checks and easy scaling across regions — use the [Quickstart](#quickstart) clone; uncomment the `image =` line in its [`fly.toml`](fly.toml) to deploy this prebuilt image instead of building.
-
-**Tags** — `:latest` tracks the newest tailscale release; `:<tailscale-version>` (e.g. `:1.98.4`) pins one. The image is `linux/amd64`, rebuilt weekly for `alpine` base-image patches, and the 25 most recent versions are kept.
-
-**Verify the signature** — the image is keyless-signed with [cosign](https://docs.sigstore.dev/) and carries SLSA provenance + an SBOM:
-
-```bash
-cosign verify ghcr.io/patte/fly-tailscale-exit:latest \
-  --certificate-identity-regexp '^https://github.com/patte/fly-tailscale-exit/' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com
-```
-
-</details>
+Add more regions with `fly scale count 1 --region fra` (see step 13 below). To deploy the prebuilt image instead of building from source, uncomment the `image =` line in the bundled [`fly.toml`](fly.toml).
 
 ## Alternative: the official Tailscale image
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,12 @@ To auto approve the fly machines as exit-nodes in tailscale. Add the following A
   },
 }
 ```
-Then uncomment `--advertise-tags=tag:fly-exit` (and `\` on the previous line) in [start.sh](start.sh) and deploy `fly deploy --strategy immediate`.
+Then set the tag via a Fly secret and redeploy:
+```
+fly secrets set TAILSCALE_ADVERTISE_TAGS=tag:fly-exit
+fly deploy --strategy immediate
+```
+([start.sh](start.sh) passes `TAILSCALE_ADVERTISE_TAGS` to `tailscale up --advertise-tags`, so no code edit is needed.)
 
 
 ## Invite your friends

--- a/env.example.sh
+++ b/env.example.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env sh
 # Template for staging Tailscale credentials as Fly secrets.
 # Copy this to env.sh (gitignored), fill in your real values, then run it.
-# Use ONE authentication method (see README step 5):
 
+# Use ONE authentication method (see README step 5):
 # Option A — OAuth client (recommended, README step 5B):
 fly secrets set TAILSCALE_OAUTH_CLIENT_ID=<your-oauth-client-id> TAILSCALE_OAUTH_SECRET=<your-oauth-client-secret>
-
 # Option B — Auth key (README step 5A):
 # fly secrets set TAILSCALE_AUTH_KEY=<your-auth-key>
+
+# Optional — advertise tags for ACL auto-approval (README "Auto approve exit nodes"):
+# fly secrets set TAILSCALE_ADVERTISE_TAGS=tag:fly-exit

--- a/fly.toml
+++ b/fly.toml
@@ -13,14 +13,6 @@ kill_timeout = "5s"
 # [build]
 #   image = "ghcr.io/patte/fly-tailscale-exit:latest"   # or pin :<tailscale-version>, e.g. :1.98.4
 
-# No [[services]] block: an exit node only needs outbound connectivity.
-# Tailscale reaches a direct path by hole-punching through Fly's (endpoint-
-# independent) NAT, so exposing the UDP port — and paying for the dedicated
-# IPv4 it would require — does NOT improve connectivity here (verified: the node
-# advertises its egress IP, never the Fly ingress IP). Whether a peer gets a
-# direct connection or falls back to Tailscale DERP relays depends on the
-# client's network, not on anything configured here.
-
 # Machine-level health check on the custom httpd port (9002). A top-level
 # [checks] block (rather than [[services.http_checks]]) lets us probe 9002
 # directly. See start.sh and the healthz CGI script.
@@ -33,3 +25,13 @@ kill_timeout = "5s"
     interval = "15s"
     timeout = "2s"
     grace_period = "30s"
+
+# No [[services]] block: a dedicated IPv4 + exposed UDP port can't improve P2P
+# for an exit node, for two reasons:
+#   1. Fly's egress NAT is endpoint-independent, so Tailscale hole-punches a
+#      direct path for free — no public endpoint needed.
+#   2. Even if you wanted the paid IP, tailscaled advertises the machine's egress
+#      IP (via STUN), never Fly's ingress Anycast IP, so it's never reachable as
+#      an endpoint anyway. ([#8862](https://github.com/tailscale/tailscale/issues/8862))
+# (Verified.) Whether a peer goes direct or falls back to Tailscale DERP relays
+# then depends on the client's NAT, not on anything configured here.

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,11 @@ primary_region = "nrt"
 kill_signal = "SIGINT"
 kill_timeout = "5s"
 
+# By default `fly deploy` builds the Dockerfile in this repo. To deploy the
+# prebuilt, signed image instead, uncomment:
+# [build]
+#   image = "ghcr.io/patte/fly-tailscale-exit:latest"   # or pin :<tailscale-version>, e.g. :1.98.4
+
 [env]
   PORT = "41641"
 

--- a/fly.toml
+++ b/fly.toml
@@ -13,9 +13,6 @@ kill_timeout = "5s"
 # [build]
 #   image = "ghcr.io/patte/fly-tailscale-exit:latest"   # or pin :<tailscale-version>, e.g. :1.98.4
 
-[env]
-  PORT = "41641"
-
 # No [[services]] block: an exit node only needs outbound connectivity.
 # Tailscale reaches a direct path by hole-punching through Fly's (endpoint-
 # independent) NAT, so exposing the UDP port — and paying for the dedicated

--- a/fly.toml
+++ b/fly.toml
@@ -16,23 +16,17 @@ kill_timeout = "5s"
 [env]
   PORT = "41641"
 
-[[services]]
-  protocol = "udp"
-  internal_port = 41641
-  processes = ["app"]
+# No [[services]] block: an exit node only needs outbound connectivity.
+# Tailscale reaches a direct path by hole-punching through Fly's (endpoint-
+# independent) NAT, so exposing the UDP port — and paying for the dedicated
+# IPv4 it would require — does NOT improve connectivity here (verified: the node
+# advertises its egress IP, never the Fly ingress IP). Whether a peer gets a
+# direct connection or falls back to Tailscale DERP relays depends on the
+# client's network, not on anything configured here.
 
-  [[services.ports]]
-    port = 41641
-
-  [services.concurrency]
-    type = "connections"
-    hard_limit = 100
-    soft_limit = 75
-
-# Machine-level health check. A top-level [checks] block is required here because
-# it lets us probe a custom port (9002): [[services.http_checks]] always targets
-# the service's internal_port (41641/udp), which has no TCP listener.
-# see start.sh and the healthz CGI script.
+# Machine-level health check on the custom httpd port (9002). A top-level
+# [checks] block (rather than [[services.http_checks]]) lets us probe 9002
+# directly. See start.sh and the healthz CGI script.
 [checks]
   [checks.health]
     type = "http"

--- a/start.sh
+++ b/start.sh
@@ -71,20 +71,16 @@ else
 fi
 
 # Optionally advertise tags (requires matching ACL tagOwners, see README).
-# Set TAILSCALE_ADVERTISE_TAGS=tag:fly-exit (comma-separated) to enable.
-ADVERTISE_TAGS=""
-if [ -n "$TAILSCALE_ADVERTISE_TAGS" ]; then
-    ADVERTISE_TAGS="--advertise-tags=${TAILSCALE_ADVERTISE_TAGS}"
-fi
-
-# ADVERTISE_TAGS must stay unquoted: empty means "pass no flag", so a quoted
-# "" would hand tailscale up a bogus empty argument.
+# Set TAILSCALE_ADVERTISE_TAGS=tag:fly-exit (comma-separated, no spaces).
+# ${VAR:+...} adds the flag only when the var is set and drops it when empty.
+# Unquoted on purpose: a tag list is a single token (tags contain no spaces),
+# so there's nothing to word-split.
 # shellcheck disable=SC2086
 /app/tailscale up \
     --auth-key="${AUTH_KEY}" \
     --hostname="fly-${FLY_REGION}" \
     --advertise-exit-node \
-    ${ADVERTISE_TAGS}
+    ${TAILSCALE_ADVERTISE_TAGS:+--advertise-tags=$TAILSCALE_ADVERTISE_TAGS}
 
 echo "Tailscale started. Let's go!"
 

--- a/start.sh
+++ b/start.sh
@@ -70,11 +70,21 @@ else
     AUTH_KEY="$TAILSCALE_AUTH_KEY"
 fi
 
+# Optionally advertise tags (requires matching ACL tagOwners, see README).
+# Set TAILSCALE_ADVERTISE_TAGS=tag:fly-exit (comma-separated) to enable.
+ADVERTISE_TAGS=""
+if [ -n "$TAILSCALE_ADVERTISE_TAGS" ]; then
+    ADVERTISE_TAGS="--advertise-tags=${TAILSCALE_ADVERTISE_TAGS}"
+fi
+
+# ADVERTISE_TAGS must stay unquoted: empty means "pass no flag", so a quoted
+# "" would hand tailscale up a bogus empty argument.
+# shellcheck disable=SC2086
 /app/tailscale up \
     --auth-key="${AUTH_KEY}" \
     --hostname="fly-${FLY_REGION}" \
-    --advertise-exit-node #\
-    #--advertise-tags=tag:fly-exit # requires ACL tagOwners
+    --advertise-exit-node \
+    ${ADVERTISE_TAGS}
 
 echo "Tailscale started. Let's go!"
 


### PR DESCRIPTION
## What

Publishes a **signed** container image to GHCR so the exit node can be deployed without cloning — and, while verifying that end-to-end, corrects the repo's long‑standing (and costly) claim that direct peer‑to‑peer connectivity requires a dedicated IPv4.

## Changes

**Publishing pipeline**
- **`publish.yml`** — builds `linux/amd64`, pushes `:latest` + `:<tailscale-version>`, attaches SLSA provenance + SBOM, cosign keyless‑signs the digest, then prunes to the 25 most‑recent releases. Gated on the healthz smoke test, serialized with a `concurrency` group, and rebuilt weekly (Wed) for `alpine` base patches. The image is named after the repo (lowercased) so forks/test repos get their own package. Skeleton follows GitHub's `docker-publish` starter template (`metadata-action` for tags + labels).
- **`prune-ghcr.sh`** — custom `gh`‑CLI retention prune. A release is *several* GHCR versions (release index + provenance/SBOM attestation children + cosign **referrers** index + signature manifest); the script keeps/drops all of them together. Off‑the‑shelf "delete untagged" actions would delete a release's own children/signature.
- **`auto-update-tailscale.yml`** — dispatches publish after a tailscale bump (a `GITHUB_TOKEN` push can't trigger other workflows; `workflow_dispatch` via API is exempt, so no PAT needed).
- **`ci.yml`** — shellcheck the new script.

**Image / config**
- **`start.sh` + `env.example.sh`** — `--advertise-tags` is now driven by `TAILSCALE_ADVERTISE_TAGS`, so ACL tag auto‑approval needs no code edit (and works for image‑only deploys).
- **`fly.toml`** — commented `[build].image` line (uncomment to deploy the prebuilt image without building); **removed the `[[services]]` UDP block** (see verification below).

**Docs**
- **`README.md`** — new "deploy straight from the image (no clone)" quickstart (`fly apps create` + `fly secrets set` + `fly machine run`), and corrected the dedicated‑IPv4 / DERP narrative throughout.

## Verified end‑to‑end

Ran the whole thing against a throwaway repo + Fly app before landing.

**Publish/prune** — caught and fixed a real bug: cosign signs via the **OCI 1.1 Referrers API** (`sha256-<hex>` tags, no `.sig`), which the first prune mis‑counted as releases and deleted real release indexes. Final state confirmed: correct `:latest` + `:<version>` tags, provenance (`slsa.dev/provenance/v1`) + SBOM (`spdx.dev`) attached, `cosign verify` passes against the workflow identity, and the prune keeps the N newest releases (5 versions each) while deleting older full sets + orphans.

**The dedicated‑IPv4 / P2P claim** (the surprise) — deployed the image and pinged the node from two clients:

| Client | Server config | Result |
|---|---|---|
| hard‑NAT mobile hotspot | none | DERP |
| hard‑NAT mobile hotspot | dedicated IPv4 + `--port 41641/udp` | **DERP** |
| normal network | dedicated IPv4 + `--port`, *then IP released* | **direct** |
| normal network | nothing (minimal `fly machine run`) | **direct** |

→ **Direct P2P is automatic and free** via Tailscale hole‑punching (Fly's NAT is endpoint‑independent). The dedicated IPv4 + UDP port **do not help** — `tailscaled` advertises the machine's egress IP, never the Fly ingress IP (the `fly-global-services` bind gap), so the paid IP goes unused. Direct vs DERP depends on the **client's** NAT, not on anything on the node. That's why this PR removes the `[[services]]` block and rewrites the IPv4/P2P docs. (The old claim was likely true in the Nomad/Apps‑V1 era when the machine IP *was* the dedicated IP.)

## Before merging / after first publish

- **Make the GHCR package public** once publish has run once (new packages default to **private**) so anonymous `fly machine run` pulls and the README commands work.
- The prune relies on `GITHUB_TOKEN` + `packages: write` (works when the package inherits repo access; a PAT with `delete:packages` is the documented fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
